### PR TITLE
ci(dependabot): add groups to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,28 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      fontawesome:
+        patterns:
+          - "@fortawesome/*"
+      eslint:
+        patterns:
+          - "eslint"
+          - "typescript-eslint"
+          - "@eslint/*"
+          - "eslint-*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+      vitest:
+        patterns:
+          - "vitest"
+          - "@vitest/*"
+      vite:
+        patterns:
+          - "vite"
+          - "@vitejs/*"


### PR DESCRIPTION
### Description

Add groups to Dependabot to address the issue of too many PRs as well as failed PRs due to inconsistent dependencies.

### Related Issues

Add groups for dependabot (#44)

### Types of change
- - [ ] Bug fix (fix)
- - [ ] New feature (feat)
- - [ ] Breaking change
- - [x] Non-user-facing change (chore, refactor, test, ci, docs, style, build, perf)
- - [ ] Other: *describe here*
